### PR TITLE
Path relationship and non-lowercase query fixes

### DIFF
--- a/__tests__/unit/pattern_analysis_engine.test.ts
+++ b/__tests__/unit/pattern_analysis_engine.test.ts
@@ -57,8 +57,8 @@ describe("Pattern analysis engine", () => {
       expect(result).toHaveLength(2);
     });
 
-    it("?(t1 or t3)", async () => {
-      const result = await basicEngine.run("?(t1 or t3)");
+    it("?(t1 or T3)", async () => {
+      const result = await basicEngine.run("?(t1 or T3)");
 
       expect(result).toBeDefined();
       expect(result).toHaveLength(4);
@@ -71,8 +71,8 @@ describe("Pattern analysis engine", () => {
       expect(result).toHaveLength(1);
     });
 
-    it("?('1':t1)", async () => {
-      const result = await basicEngine.run("?('1':t1)");
+    it("?('1':T1)", async () => {
+      const result = await basicEngine.run("?('1':T1)");
 
       expect(result).toBeDefined();
       expect(result).toHaveLength(1);

--- a/__tests__/unit/query_engine.test.ts
+++ b/__tests__/unit/query_engine.test.ts
@@ -1,4 +1,4 @@
-import { DerivationEngine, DerivationRule } from "../../src/libs";
+import { DerivationEngine, DerivationRule } from "../../src";
 import { initBasicGraph } from "./utils/graphs/initBasicGraph";
 import { initComplexGraph } from "./utils/graphs/initComplexGraph";
 import { QueryEngine } from "../../src/libs/engine/query_engine";
@@ -30,7 +30,7 @@ describe("Query engine", () => {
     complexGraphEngine = new DerivationEngine(complexGraph, complexGraphRules);
 
     await basicGraphEngine.deriveEdges(1);
-    await complexGraphEngine.deriveEdges(2);
+    await complexGraphEngine.deriveEdges(1);
 
     basicQueryEngine = new QueryEngine(basicGraph);
     complexQueryEngine = new QueryEngine(complexGraph);
@@ -78,7 +78,7 @@ describe("Query engine", () => {
       );
 
       expect(result).toBeDefined();
-      expect(result.length).toBeGreaterThan(0);
+      expect(result.length).toBe(2);
     });
 
     it("?(t2)=[et2]=>(*)->(*)", async () => {
@@ -89,7 +89,7 @@ describe("Query engine", () => {
       );
 
       expect(result).toBeDefined();
-      expect(result.length).toBeGreaterThan(0);
+      expect(result.length).toBe(1);
     });
   });
 
@@ -135,7 +135,7 @@ describe("Query engine", () => {
       );
 
       expect(result).toBeDefined();
-      expect(result.length).toBeGreaterThan(0);
+      expect(result.length).toBe(2);
     });
 
     it("?(f)=[e1]=>(*)", async () => {
@@ -146,7 +146,7 @@ describe("Query engine", () => {
       );
 
       expect(result).toBeDefined();
-      expect(result.length).toBeGreaterThan(0);
+      expect(result.length).toBe(2);
     });
   });
 });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peritoz/pattern-analysis-engine",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "User friendly query engine for functional analysis",
   "author": "diorbert.pereira",
   "main": "dist/lib/index.js",

--- a/src/libs/engine/graph_repository/simple_graph_repository.class.ts
+++ b/src/libs/engine/graph_repository/simple_graph_repository.class.ts
@@ -194,7 +194,7 @@ export class SimpleGraphRepository implements GraphRepository {
       // First case: Some candidate vertices were selected
       if (candidates.length > 0) {
         candidates = candidates.filter((candidate) =>
-          candidate.types.some((t) => filter.types?.includes(t))
+          candidate.types.some((t) => filter.types?.includes(t.toLowerCase()))
         );
       } else {
         // Second case: There are no candidates available
@@ -302,8 +302,8 @@ export class SimpleGraphRepository implements GraphRepository {
 
             // Verifying if the edge conforms with the constraints
             if (edge) {
-              const fulfillsTypeConstraints = edgeFilter.types?.every((e) =>
-                edge.types.includes(e)
+              const fulfillsTypeConstraints = edgeFilter.types?.every(
+                (edgeType) => edge.types.includes(edgeType.toLowerCase())
               );
               let fulfillsDerivationConstraint = true;
 

--- a/src/libs/engine/graph_repository/simple_graph_repository.class.ts
+++ b/src/libs/engine/graph_repository/simple_graph_repository.class.ts
@@ -307,16 +307,10 @@ export class SimpleGraphRepository implements GraphRepository {
               );
               let fulfillsDerivationConstraint = true;
 
-              if (edgeFilter.isDerived !== undefined && edgeFilter.isDerived) {
+              if (!edgeFilter.isDerived) {
                 fulfillsDerivationConstraint =
-                  edge.derivationPath !== undefined
-                    ? edge.derivationPath.length > 0
-                    : false;
-              } else {
-                fulfillsDerivationConstraint =
-                  edge.derivationPath !== undefined
-                    ? edge.derivationPath.length === 0
-                    : true;
+                  edge.derivationPath === undefined ||
+                  edge.derivationPath.length === 0;
               }
 
               if (fulfillsTypeConstraints && fulfillsDerivationConstraint) {

--- a/src/libs/model/input_descriptor/input_node.class.ts
+++ b/src/libs/model/input_descriptor/input_node.class.ts
@@ -1,26 +1,38 @@
-import {NodeDiscriminator} from "@libs/model/input_descriptor/enums/node_discriminator.enum";
+import { NodeDiscriminator } from "@libs/model/input_descriptor/enums/node_discriminator.enum";
 
 export class InputNode {
-    constructor(
-        protected _discriminator: NodeDiscriminator,
-        protected _alias: string,
-        protected _types: Array<string>,
-        protected _searchTerm: string
-    ) {}
+  protected _discriminator: NodeDiscriminator;
+  protected _alias: string;
+  protected _types: Array<string>;
+  protected _searchTerm: string;
 
-    get discriminator(): NodeDiscriminator {
-        return this._discriminator;
-    }
+  constructor(
+    _discriminator: NodeDiscriminator,
+    _alias: string,
+    _types: Array<string>,
+    _searchTerm: string
+  ) {
+    this._discriminator = _discriminator;
+    this._alias = _alias;
+    this._types = Array.isArray(_types)
+      ? _types.map((t) => t.toLowerCase())
+      : [];
+    this._searchTerm = _searchTerm.toLowerCase();
+  }
 
-    get alias(): string {
-        return this._alias;
-    }
+  get discriminator(): NodeDiscriminator {
+    return this._discriminator;
+  }
 
-    get types(): Array<string> {
-        return this._types;
-    }
+  get alias(): string {
+    return this._alias;
+  }
 
-    get searchTerm(): string {
-        return this._searchTerm;
-    }
+  get types(): Array<string> {
+    return this._types;
+  }
+
+  get searchTerm(): string {
+    return this._searchTerm;
+  }
 }

--- a/src/libs/model/input_descriptor/input_relationship.class.ts
+++ b/src/libs/model/input_descriptor/input_relationship.class.ts
@@ -1,94 +1,116 @@
-import {RelationshipDiscriminator} from "@libs/model/input_descriptor/enums/relationship_discriminator.enum";
-import {ConnectorDiscriminator} from "@libs/model/input_descriptor/enums/connector_discriminator.enum";
+import { RelationshipDiscriminator } from "@libs/model/input_descriptor/enums/relationship_discriminator.enum";
+import { ConnectorDiscriminator } from "@libs/model/input_descriptor/enums/connector_discriminator.enum";
 
 const derivedDiscriminators = [
-    ConnectorDiscriminator.PATH_LEFT,
-    ConnectorDiscriminator.PATH_RIGHT,
-    ConnectorDiscriminator.PATH_BASE
+  ConnectorDiscriminator.PATH_LEFT,
+  ConnectorDiscriminator.PATH_RIGHT,
+  ConnectorDiscriminator.PATH_BASE,
 ];
 
 export class InputRelationship {
-    constructor(
-        protected _discriminator: RelationshipDiscriminator,
-        protected _sourceDisc: ConnectorDiscriminator,
-        protected _targetDisc: ConnectorDiscriminator,
-        protected _alias: string,
-        protected _types: Array<string>,
-        protected _isNegated: boolean
+  protected _discriminator: RelationshipDiscriminator;
+  protected _sourceDisc: ConnectorDiscriminator;
+  protected _targetDisc: ConnectorDiscriminator;
+  protected _alias: string;
+  protected _types: Array<string>;
+  protected _isNegated: boolean;
+
+  constructor(
+    _discriminator: RelationshipDiscriminator,
+    _sourceDisc: ConnectorDiscriminator,
+    _targetDisc: ConnectorDiscriminator,
+    _alias: string,
+    _types: Array<string>,
+    _isNegated: boolean
+  ) {
+    this._discriminator = _discriminator;
+    this._sourceDisc = _sourceDisc;
+    this._targetDisc = _targetDisc;
+    this._alias = _alias;
+    this._types = Array.isArray(_types)
+      ? _types.map((t) => t.toLowerCase())
+      : [];
+    this._isNegated = _isNegated;
+  }
+
+  get discriminator(): RelationshipDiscriminator {
+    return this._discriminator;
+  }
+
+  get sourceDisc(): ConnectorDiscriminator {
+    return this._sourceDisc;
+  }
+
+  set sourceDisc(value: ConnectorDiscriminator) {
+    this._sourceDisc = value;
+  }
+
+  get targetDisc(): ConnectorDiscriminator {
+    return this._targetDisc;
+  }
+
+  set targetDisc(value: ConnectorDiscriminator) {
+    this._targetDisc = value;
+  }
+
+  get alias(): string {
+    return this._alias;
+  }
+
+  set alias(value: string) {
+    this._alias = value;
+  }
+
+  get types(): Array<string> {
+    return this._types;
+  }
+
+  get isNegated(): boolean {
+    return this._isNegated;
+  }
+
+  get isBidirectional(): boolean {
+    return this.getDirectionAsNumber() === 0;
+  }
+
+  get isSourceDerived(): boolean {
+    return derivedDiscriminators.includes(this._sourceDisc);
+  }
+
+  get isTargetDerived(): boolean {
+    return derivedDiscriminators.includes(this._targetDisc);
+  }
+
+  /**
+   * Indicates that the relationship has both connectors of the same nature (PATH or BONDED)
+   *
+   * @return true if source discriminator and target discriminator are both classified as PATH or BONDED
+   */
+  get isHomogeneous(): boolean {
+    return (
+      (this.isSourceDerived && this.isTargetDerived) ||
+      (!this.isSourceDerived && !this.isTargetDerived)
+    );
+  }
+
+  /**
+   * Provides the direction as a number from -1 to 1
+   *
+   * @return -1 if the relationship points to the left, 0 if bidirectional and 1 if the relationship points to the right
+   */
+  getDirectionAsNumber(): number {
+    if (
+      (this.sourceDisc === "BONDED_BASE" || this.sourceDisc === "PATH_BASE") &&
+      (this.targetDisc === "BONDED_RIGHT" || this.targetDisc === "PATH_RIGHT")
     ) {
+      return 1;
+    } else if (
+      (this.sourceDisc === "BONDED_LEFT" || this.sourceDisc === "PATH_LEFT") &&
+      (this.targetDisc === "BONDED_BASE" || this.targetDisc === "PATH_BASE")
+    ) {
+      return -1;
+    } else {
+      return 0;
     }
-
-    get discriminator(): RelationshipDiscriminator {
-        return this._discriminator;
-    }
-
-    get sourceDisc(): ConnectorDiscriminator {
-        return this._sourceDisc;
-    }
-
-    set sourceDisc(value: ConnectorDiscriminator) {
-        this._sourceDisc = value;
-    }
-
-    get targetDisc(): ConnectorDiscriminator {
-        return this._targetDisc;
-    }
-
-    set targetDisc(value: ConnectorDiscriminator) {
-        this._targetDisc = value;
-    }
-
-    get alias(): string {
-        return this._alias;
-    }
-
-    set alias(value: string) {
-        this._alias = value;
-    }
-
-    get types(): Array<string> {
-        return this._types;
-    }
-
-    get isNegated(): boolean {
-        return this._isNegated;
-    }
-
-    get isBidirectional(): boolean {
-        return this.getDirectionAsNumber() === 0;
-    }
-
-    get isSourceDerived(): boolean {
-        return derivedDiscriminators.includes(this._sourceDisc);
-    }
-
-    get isTargetDerived(): boolean {
-        return derivedDiscriminators.includes(this._targetDisc);
-    }
-
-    /**
-     * Indicates that the relationship has both connectors of the same nature (PATH or BONDED)
-     *
-     * @return true if source discriminator and target discriminator are both classified as PATH or BONDED
-     */
-    get isHomogeneous(): boolean {
-        return (this.isSourceDerived && this.isTargetDerived) || (!this.isSourceDerived && !this.isTargetDerived);
-    }
-
-    /**
-     * Provides the direction as a number from -1 to 1
-     *
-     * @return -1 if the relationship points to the left, 0 if bidirectional and 1 if the relationship points to the right
-     */
-    getDirectionAsNumber(): number {
-        if ((this.sourceDisc === 'BONDED_BASE' || this.sourceDisc === 'PATH_BASE') &&
-            (this.targetDisc === 'BONDED_RIGHT' || this.targetDisc === 'PATH_RIGHT')) {
-            return 1;
-        } else if ((this.sourceDisc === 'BONDED_LEFT' || this.sourceDisc === 'PATH_LEFT') &&
-            (this.targetDisc === 'BONDED_BASE' || this.targetDisc === 'PATH_BASE')) {
-            return -1;
-        } else {
-            return 0;
-        }
-    }
+  }
 }


### PR DESCRIPTION
This PR fixes two bugs:

1. Path relationships queries should return edges that conform to a derived or non-derived edge but are returning only derived edges.
2. Vertices and edges with non-lowercase types are returning invalid results (e.g.: *?(Type1)*).