### PR TITLE
Simple Graph Optimization

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,12 +47,12 @@ The following example shows how to use the in-memory Graph Repository to get sta
 const graph = new SimpleGraphRepository();
 
 // Adding vertices
-// SimpleGraphVertex receives VertexName, Types and External Vertex Id
+// SimpleGraphVertex receives Vertex Name, Types and External Vertex Id
 await graph.addVertex(new SimpleGraphVertex("V1", ["t1", "t2"], "1"));
 await graph.addVertex(new SimpleGraphVertex("V2", ["t1"], "2"));
 
 // Adding an edge
-// SimpleGraphEdge receives SourceId, TargetId, Types and External Edge Id
+// SimpleGraphEdge receives Source Id, Target Id, Types and External Edge Id
 await graph.addEdge(new SimpleGraphEdge("1", "2", ["et1", "et2"], "E1"));
 ```
 

--- a/__tests__/unit/complex_pattern_matching.test.ts
+++ b/__tests__/unit/complex_pattern_matching.test.ts
@@ -1,6 +1,5 @@
 import { validateQueryChain } from "./utils/validateQueryChain";
-import { InputNode } from "../../src/libs/model/input_descriptor/input_node.class";
-import { InputRelationship } from "../../src/libs/model/input_descriptor/input_relationship.class";
+import { InputNode, InputRelationship } from "../../src";
 import { QueryDescriptor } from "../../src/libs/model/query_descriptor/query_descriptor.class";
 import { validateQueryDescriptor } from "./utils/validateQueryDescriptor";
 import { OhmInterpreter } from "../../src/libs/engine/query_interpreter";

--- a/__tests__/unit/derivation_engine.test.ts
+++ b/__tests__/unit/derivation_engine.test.ts
@@ -82,7 +82,7 @@ describe("Derivation engine", () => {
         { types: ["t2", "t3"] }
       );
 
-      expect(edgeGroupRule3.length).toBe(1);
+      expect(edgeGroupRule3.length).toBe(3);
     });
   });
 

--- a/__tests__/unit/derivation_engine.test.ts
+++ b/__tests__/unit/derivation_engine.test.ts
@@ -1,4 +1,4 @@
-import { DerivationEngine, DerivationRule } from "../../src/libs";
+import { DerivationEngine, DerivationRule } from "../../src";
 import { initBasicGraph } from "./utils/graphs/initBasicGraph";
 import { initComplexGraph } from "./utils/graphs/initComplexGraph";
 import { EdgeScope } from "../../src/libs/model/graph_repository/enums/edge_scope.enum";

--- a/__tests__/unit/query_engine.test.ts
+++ b/__tests__/unit/query_engine.test.ts
@@ -118,7 +118,7 @@ describe("Query engine", () => {
       );
 
       expect(result).toBeDefined();
-      expect(result.length).toBe(1);
+      expect(result.length).toBe(2);
     });
   });
 

--- a/__tests__/unit/query_translation.test.ts
+++ b/__tests__/unit/query_translation.test.ts
@@ -1,6 +1,5 @@
 import { OhmInterpreter } from "../../src/libs/engine/query_interpreter";
-import { InputNode } from "../../src/libs/model/input_descriptor/input_node.class";
-import { InputRelationship } from "../../src/libs/model/input_descriptor/input_relationship.class";
+import { InputNode, InputRelationship } from "../../src";
 import { validateQueryChain } from "./utils/validateQueryChain";
 import { QueryDescriptor } from "../../src/libs/model/query_descriptor/query_descriptor.class";
 import { NodeDiscriminator } from "../../src/libs/model/input_descriptor/enums/node_discriminator.enum";
@@ -160,30 +159,30 @@ describe("Query Translation", () => {
         validateQueryChain(inputDescriptor, [
           new InputNode(NodeDiscriminator.TYPED_NODE, "", ["a"], ""),
           new InputRelationship(
-              RelationshipDiscriminator.TYPED_RELATIONSHIP,
-              ConnectorDiscriminator.PATH_BASE,
-              ConnectorDiscriminator.PATH_RIGHT,
-              "",
-              ["r1"],
-              false
+            RelationshipDiscriminator.TYPED_RELATIONSHIP,
+            ConnectorDiscriminator.PATH_BASE,
+            ConnectorDiscriminator.PATH_RIGHT,
+            "",
+            ["r1"],
+            false
           ),
           new InputNode(NodeDiscriminator.TYPED_NODE, "", ["b"], ""),
           new InputRelationship(
-              RelationshipDiscriminator.TYPED_RELATIONSHIP,
-              ConnectorDiscriminator.PATH_BASE,
-              ConnectorDiscriminator.PATH_RIGHT,
-              "",
-              ["r2"],
-              false
+            RelationshipDiscriminator.TYPED_RELATIONSHIP,
+            ConnectorDiscriminator.PATH_BASE,
+            ConnectorDiscriminator.PATH_RIGHT,
+            "",
+            ["r2"],
+            false
           ),
           new InputNode(NodeDiscriminator.DESCRIBED_NODE, "", ["c"], "C"),
           new InputRelationship(
-              RelationshipDiscriminator.SHORT_RELATIONSHIP,
-              ConnectorDiscriminator.BONDED_LEFT,
-              ConnectorDiscriminator.BONDED_BASE,
-              "",
-              [],
-              false
+            RelationshipDiscriminator.SHORT_RELATIONSHIP,
+            ConnectorDiscriminator.BONDED_LEFT,
+            ConnectorDiscriminator.BONDED_BASE,
+            "",
+            [],
+            false
           ),
           new InputNode(NodeDiscriminator.GROUP_NODE, "", [], ""),
         ])

--- a/__tests__/unit/simple_graph_repository.test.ts
+++ b/__tests__/unit/simple_graph_repository.test.ts
@@ -1,7 +1,9 @@
-import { SimpleGraphRepository } from "../../src";
+import {
+  SimpleGraphRepository,
+  SimpleGraphVertex,
+  SimpleGraphEdge,
+} from "../../src";
 import { EdgeScope } from "../../src/libs/model/graph_repository/enums/edge_scope.enum";
-import { SimpleGraphVertex } from "../../src/libs/engine/simple_graph_repository/simple_graph_vertex";
-import { SimpleGraphEdge } from "../../src/libs/engine/simple_graph_repository/simple_graph_edge";
 
 /**
  *  Tests the Simple Graph Repository.
@@ -74,7 +76,7 @@ describe("Simple Graph Repository", () => {
 
   it("Should confirm that an vertex does not exists", async () => {
     const exists = await repository.exists(
-        new SimpleGraphVertex("V100", ["t1"], "100")
+      new SimpleGraphVertex("V100", ["t1"], "100")
     );
 
     expect(exists).toBeFalsy();
@@ -156,7 +158,7 @@ describe("Simple Graph Repository", () => {
 
   it("Should confirm that an edge exists", async () => {
     const exists = await repository.exists(
-        new SimpleGraphEdge("1", "3", ["et2"], "E2")
+      new SimpleGraphEdge("1", "3", ["et2"], "E2")
     );
 
     expect(exists).toBeTruthy();
@@ -164,7 +166,7 @@ describe("Simple Graph Repository", () => {
 
   it("Should confirm that an edge does not exists", async () => {
     const exists = await repository.exists(
-        new SimpleGraphEdge("10", "1", ["et1"], "E10")
+      new SimpleGraphEdge("10", "1", ["et1"], "E10")
     );
 
     expect(exists).toBeFalsy();

--- a/__tests__/unit/utils/graphs/initBasicGraph.ts
+++ b/__tests__/unit/utils/graphs/initBasicGraph.ts
@@ -1,6 +1,8 @@
-import { SimpleGraphRepository } from "../../../../src";
-import { SimpleGraphVertex } from "../../../../src/libs/engine/simple_graph_repository/simple_graph_vertex";
-import {SimpleGraphEdge} from "../../../../src/libs/engine/simple_graph_repository/simple_graph_edge";
+import {
+  SimpleGraphRepository,
+  SimpleGraphVertex,
+  SimpleGraphEdge,
+} from "../../../../src";
 
 /**
  * Creates a graph in the following form:

--- a/__tests__/unit/utils/graphs/initComplexGraph.ts
+++ b/__tests__/unit/utils/graphs/initComplexGraph.ts
@@ -1,6 +1,8 @@
-import {SimpleGraphRepository} from "../../../../src";
-import {SimpleGraphVertex} from "../../../../src/libs/engine/simple_graph_repository/simple_graph_vertex";
-import {SimpleGraphEdge} from "../../../../src/libs/engine/simple_graph_repository/simple_graph_edge";
+import {
+  SimpleGraphRepository,
+  SimpleGraphVertex,
+  SimpleGraphEdge,
+} from "../../../../src";
 
 /**
  * Creates a graph in the following form:

--- a/__tests__/unit/utils/graphs/initLongPathsGraph.ts
+++ b/__tests__/unit/utils/graphs/initLongPathsGraph.ts
@@ -1,6 +1,8 @@
-import {SimpleGraphRepository} from "../../../../src";
-import {SimpleGraphVertex} from "../../../../src/libs/engine/simple_graph_repository/simple_graph_vertex";
-import {SimpleGraphEdge} from "../../../../src/libs/engine/simple_graph_repository/simple_graph_edge";
+import {
+  SimpleGraphRepository,
+  SimpleGraphVertex,
+  SimpleGraphEdge,
+} from "../../../../src";
 
 /**
  * Creates a graph in the following form:

--- a/__tests__/unit/utils/validateQueryChain.ts
+++ b/__tests__/unit/utils/validateQueryChain.ts
@@ -1,6 +1,4 @@
-import { InputDescriptor } from "../../../src/libs/model/input_descriptor/input_descriptor.class";
-import { InputNode } from "../../../src/libs/model/input_descriptor/input_node.class";
-import { InputRelationship } from "../../../src/libs/model/input_descriptor/input_relationship.class";
+import { InputDescriptor, InputNode, InputRelationship } from "../../../src";
 
 export function validateQueryChain(
   inputDescriptor: InputDescriptor,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@peritoz/pattern-analysis-engine",
-  "version": "0.1.6",
+  "version": "0.2.0",
   "description": "User friendly query engine for functional analysis",
   "author": "diorbert.pereira",
   "main": "dist/lib/index.js",

--- a/src/libs/engine/simple_graph_repository/simple_graph_repository.class.ts
+++ b/src/libs/engine/simple_graph_repository/simple_graph_repository.class.ts
@@ -327,9 +327,9 @@ export class SimpleGraphRepository implements GraphRepository {
   }
 
   private filterEdges(
-      edges: Array<SimpleGraphEdge>,
-      type: string,
-      scope: EdgeScope = EdgeScope.ALL
+    edges: Array<SimpleGraphEdge>,
+    type: string,
+    scope: EdgeScope = EdgeScope.ALL
   ) {
     let candidates = edges;
 
@@ -363,7 +363,7 @@ export class SimpleGraphRepository implements GraphRepository {
       targetFilter !== null && Object.entries(targetFilter).length > 0;
     let candidates: Array<SimpleGraphEdge> = [];
 
-    // Looking up for edges based on scope and types
+    // Looking up edges based on scope and types
     if (Array.isArray(edgeFilter.types) && edgeFilter.types.length > 0) {
       for (let i = 0; i < edgeFilter.types.length; i++) {
         const type = edgeFilter.types[i];
@@ -382,6 +382,11 @@ export class SimpleGraphRepository implements GraphRepository {
         )
       );
     }
+
+    // Removing duplicates
+    candidates = candidates.filter((edge,currentPos) => {
+      return candidates.indexOf(edge) === currentPos;
+    });
 
     // Extracting source and target ids
     let sourceVerticesIds = candidates.map((e) => e.sourceId);

--- a/src/libs/engine/simple_graph_repository/simple_graph_repository.class.ts
+++ b/src/libs/engine/simple_graph_repository/simple_graph_repository.class.ts
@@ -116,22 +116,27 @@ export class SimpleGraphRepository implements GraphRepository {
   addEdge(edge: SimpleGraphEdge): void {
     const adjListElements = this._adjacencyListMap.get(edge.sourceId);
     const adjListElement = `${edge.types.join(",")}>${edge.targetId}`;
-    const isDerived = edge.derivationPath && edge.derivationPath.length > 0;
 
     if (Array.isArray(adjListElements)) {
       if (!adjListElements.includes(adjListElement)) {
         adjListElements.push(adjListElement);
 
-        this.mapEdge(edge, isDerived);
+        this.mapEdge(edge);
       }
     } else {
       this._adjacencyListMap.set(edge.sourceId, [adjListElement]);
 
-      this.mapEdge(edge, isDerived);
+      this.mapEdge(edge);
     }
   }
 
-  private mapEdge(edge: SimpleGraphEdge, isDerived: boolean) {
+  /**
+   * Maps the edge in nested maps based on scope, from Edge Type -> Source Vertex Type
+   * @param edge Edge to be mapped
+   */
+  private mapEdge(edge: SimpleGraphEdge): void {
+    const isDerived = edge.derivationPath && edge.derivationPath.length > 0;
+
     this._edgesMap.set(edge.getId(), edge);
 
     for (let i = 0; i < edge.types.length; i++) {
@@ -384,7 +389,7 @@ export class SimpleGraphRepository implements GraphRepository {
     }
 
     // Removing duplicates
-    candidates = candidates.filter((edge,currentPos) => {
+    candidates = candidates.filter((edge, currentPos) => {
       return candidates.indexOf(edge) === currentPos;
     });
 

--- a/src/libs/model/graph_repository/graph_repository.interface.ts
+++ b/src/libs/model/graph_repository/graph_repository.interface.ts
@@ -4,12 +4,14 @@ export interface VertexFilter {
   ids: Array<string>;
   searchTerm: string;
   types: Array<string>;
+  inclusiveTypes: boolean; // = true means that should select vertices with any of the types
 }
 
 export type PartialVertexFilter = Partial<VertexFilter>;
 
 export interface EdgeFilter {
   types: Array<string>;
+  inclusiveTypes: boolean; // = true means that should select edges with any of the types
   isNegated: boolean;
   scope: EdgeScope;
 }


### PR DESCRIPTION
This PR includes relevant optimization for edge search. The getEdgesByFilter has been completely redesigned, using mostly maps instead of array iteration.

This PR also includes minor bug fixes, such as the possibility of a duplicate output path.