### PR TITLE
refactor: Adding edge builder parameters in Derivation Engine class

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,21 @@ const rules = [
   new DerivationRule("()<[](t3)[et3]>(t2)", "(3)[et1,et2](1)"),
 ];
 
-const derivationEngine = new DerivationEngine(graph, rules);
+const derivationEngine = new DerivationEngine(graph, rules, (
+    sourceId: string,
+    targetId: string,
+    types: Array<string>,
+    externalId: string,
+    derivationPath: Array<string>
+) => {
+    return new SimpleGraphEdge(
+        sourceId,
+        targetId,
+        types,
+        externalId,
+        derivationPath
+    );
+});
 
 await derivationEngine.deriveEdges(2);
 ```

--- a/src/libs/engine/derivation_engine/derivation_engine.class.ts
+++ b/src/libs/engine/derivation_engine/derivation_engine.class.ts
@@ -26,7 +26,13 @@ export class DerivationEngine {
   constructor(
     graph: GraphRepository,
     rules: Array<DerivationRule>,
-    graphEdgeBuilder: () => GraphEdge
+    graphEdgeBuilder: (
+      sourceId: string,
+      targetId: string,
+      types: Array<string>,
+      externalId: string,
+      derivationPath: Array<string>
+    ) => GraphEdge
   ) {
     this._graph = graph;
     this._rules = rules;


### PR DESCRIPTION
This PR explicitly adds parameters in the "edge builder callback" of the Derivation Engine's constructor.