### PR TITLE
refactor: remove async modifier from functions that do not use await

### DIFF
--- a/__tests__/unit/derivation_engine/derivation_engine_complex_graph.test.ts
+++ b/__tests__/unit/derivation_engine/derivation_engine_complex_graph.test.ts
@@ -27,13 +27,13 @@ describe("Derivation engine", () => {
   });
 
   describe("Constructor", () => {
-    it("Should throw error: Invalid edge builder (Void function)", async () => {
+    it("Should throw error: Invalid edge builder (Void function)", () => {
       expect(() => {
         new DerivationEngine(complexGraph, [], () => {});
       }).toThrowError("Invalid edge builder");
     });
 
-    it("Should throw error: Invalid edge builder (Returning invalid format)", async () => {
+    it("Should throw error: Invalid edge builder (Returning invalid format)", () => {
       expect(() => {
         new DerivationEngine(
           complexGraph,

--- a/src/libs/engine/derivation_engine/derivation_engine.class.ts
+++ b/src/libs/engine/derivation_engine/derivation_engine.class.ts
@@ -133,7 +133,7 @@ export class DerivationEngine {
     );
   }
 
-  private async getPartCandidates(
+  private getPartCandidates(
     partDescription: RuleEdgeDescription,
     middleElementTypes: Array<string>,
     isFirstPart: boolean,

--- a/src/libs/engine/pattern_analysis_engine/pattern_analysis_engine.class.ts
+++ b/src/libs/engine/pattern_analysis_engine/pattern_analysis_engine.class.ts
@@ -15,7 +15,7 @@ export class PatternAnalysisEngine {
     this._queryEngine = new QueryEngine(this._repo);
   }
 
-  async run(
+  run(
     query: string,
     initialElementIds: Array<string> = []
   ): Promise<Array<Array<OutputVertex | OutputEdge>>> {

--- a/src/libs/engine/query_engine/query_engine.class.ts
+++ b/src/libs/engine/query_engine/query_engine.class.ts
@@ -25,7 +25,7 @@ interface StageResult {
 export class QueryEngine {
   constructor(protected _repo: GraphRepository) {}
 
-  async run(
+  run(
     queryDescriptor: QueryDescriptor,
     initialElementIds: Array<string> = []
   ): Promise<Array<Array<OutputVertex | OutputEdge>>> {

--- a/src/libs/engine/simple_graph_repository/simple_graph_repository.class.ts
+++ b/src/libs/engine/simple_graph_repository/simple_graph_repository.class.ts
@@ -252,7 +252,6 @@ export class SimpleGraphRepository implements GraphRepository {
 
       if (idParts.length === 3) {
         const [sourceId, edgeTypes, targetId] = idParts;
-        const edge = this._edgesMap.get(edgePathId);
 
         // Removing from Edges Map
         this._edgesMap.delete(edgePathId);

--- a/src/libs/engine/simple_graph_repository/simple_graph_repository.class.ts
+++ b/src/libs/engine/simple_graph_repository/simple_graph_repository.class.ts
@@ -282,7 +282,7 @@ export class SimpleGraphRepository implements GraphRepository {
 
         resolve();
       } else {
-        reject(`Invalid edge id: ${edgePathId}`);
+        reject(new Error(`Invalid edge id: ${edgePathId}`));
       }
     });
   }

--- a/src/libs/engine/simple_graph_repository/simple_graph_repository.class.ts
+++ b/src/libs/engine/simple_graph_repository/simple_graph_repository.class.ts
@@ -246,58 +246,64 @@ export class SimpleGraphRepository implements GraphRepository {
   }
 
   // TODO: Remove from maps
-  async removeEdge(edgePathId: string): Promise<void> {
-    const idParts = edgePathId.split(">");
+  removeEdge(edgePathId: string): Promise<void> {
+    return new Promise((resolve, reject) => {
+      const idParts = edgePathId.split(">");
 
-    if (idParts.length === 3) {
-      const [sourceId, edgeTypes, targetId] = idParts;
-      const edge = this._edgesMap.get(edgePathId);
+      if (idParts.length === 3) {
+        const [sourceId, edgeTypes, targetId] = idParts;
+        const edge = this._edgesMap.get(edgePathId);
 
-      // Removing from Edges Map
-      this._edgesMap.delete(edgePathId);
+        // Removing from Edges Map
+        this._edgesMap.delete(edgePathId);
 
-      // Removing from outbound adjacency list
-      const outboundAdjElement = `${edgeTypes}>${targetId}`;
+        // Removing from outbound adjacency list
+        const outboundAdjElement = `${edgeTypes}>${targetId}`;
 
-      const outboundAdjElements = this._outboundAdjListMap.get(sourceId);
+        const outboundAdjElements = this._outboundAdjListMap.get(sourceId);
 
-      if (Array.isArray(outboundAdjElements)) {
-        this._outboundAdjListMap.set(
-          sourceId,
-          outboundAdjElements.filter((e) => e !== outboundAdjElement)
-        );
+        if (Array.isArray(outboundAdjElements)) {
+          this._outboundAdjListMap.set(
+              sourceId,
+              outboundAdjElements.filter((e) => e !== outboundAdjElement)
+          );
+        }
+
+        // Removing from inbound adjacency list
+        const inboundAdjElement = `${sourceId}>${edgeTypes}`;
+
+        const inboundAdjElements = this._inboundAdjListMap.get(targetId);
+
+        if (Array.isArray(inboundAdjElements)) {
+          this._inboundAdjListMap.set(
+              targetId,
+              inboundAdjElements.filter((e) => e !== inboundAdjElement)
+          );
+        }
+
+        resolve();
+      } else {
+        reject(`Invalid edge id: ${edgePathId}`);
       }
-
-      // Removing from inbound adjacency list
-      const inboundAdjElement = `${sourceId}>${edgeTypes}`;
-
-      const inboundAdjElements = this._inboundAdjListMap.get(targetId);
-
-      if (Array.isArray(inboundAdjElements)) {
-        this._inboundAdjListMap.set(
-          targetId,
-          inboundAdjElements.filter((e) => e !== inboundAdjElement)
-        );
-      }
-    } else {
-      throw new Error(`Invalid edge id: ${edgePathId}`);
-    }
+    });
   }
 
-  async exists(element: SimpleGraphVertex | SimpleGraphEdge): Promise<boolean> {
-    if (element instanceof SimpleGraphVertex) {
-      const vertex: SimpleGraphVertex | undefined = this._verticesMap.get(
-        (element as SimpleGraphVertex).getId()
-      );
+  exists(element: SimpleGraphVertex | SimpleGraphEdge): Promise<boolean> {
+    return new Promise((resolve) => {
+      if (element instanceof SimpleGraphVertex) {
+        const vertex: SimpleGraphVertex | undefined = this._verticesMap.get(
+            (element as SimpleGraphVertex).getId()
+        );
 
-      return vertex !== undefined;
-    } else {
-      const edge: SimpleGraphEdge | undefined = this._edgesMap.get(
-        (element as SimpleGraphEdge).getId()
-      );
+        resolve(vertex !== undefined);
+      } else {
+        const edge: SimpleGraphEdge | undefined = this._edgesMap.get(
+            (element as SimpleGraphEdge).getId()
+        );
 
-      return edge !== undefined;
-    }
+        resolve(edge !== undefined);
+      }
+    })
   }
 
   getVertex(vertexId: string): Promise<SimpleGraphVertex | undefined> {


### PR DESCRIPTION
This PR fixes issues related to using async on functions that don't use async functions.