### PR TITLE
fix: wrong edge id being used when removing an edge

### DIFF
--- a/__tests__/unit/simple_graph_repository/simple_graph_repository.test.ts
+++ b/__tests__/unit/simple_graph_repository/simple_graph_repository.test.ts
@@ -228,17 +228,19 @@ describe('Simple Graph Repository', () => {
 
   it('Should remove an edge', async () => {
     const repository = await initializeGraph('full');
-    const edgeId = '1>et1>2';
+    const edgeId = 'E1';
     const edgesCountBefore = (await repository.getAllEdges()).length;
     await repository.removeEdge(edgeId);
 
     const edges = await repository.getAllEdges();
-    const adjList = repository.outboundAdjListMap;
+    const outboundAdjList = repository.outboundAdjListMap;
+    const inboundAdjList = repository.inboundAdjListMap;
 
     expect(edges).toBeDefined();
     expect(edges.length).toBe(edgesCountBefore - 1);
     expect(edges.findIndex(e => e.getId() === edgeId)).toBe(-1);
-    expect(adjList?.get('1')?.findIndex(e => e === 'et1>2')).toBe(-1);
+    expect(outboundAdjList?.get('1')?.findIndex(e => e === edgeId)).toBe(-1);
+    expect(inboundAdjList?.get('1')?.findIndex(e => e === edgeId)).toBe(-1);
   });
 
   it('Should remove all vertices', async () => {

--- a/src/libs/engine/simple_graph_repository/simple_graph_repository.class.ts
+++ b/src/libs/engine/simple_graph_repository/simple_graph_repository.class.ts
@@ -225,42 +225,32 @@ export class SimpleGraphRepository implements GraphRepository {
     }
   }
 
-  // TODO: Remove from maps
-  async removeEdge(edgePathId: string): Promise<void> {
-    const idParts = edgePathId.split('>');
+  async removeEdge(edgeId: string): Promise<void> {
+    const edge = await this.getEdge(edgeId);
+    const sourceId = edge?.sourceId ?? '';
+    const targetId = edge?.targetId ?? '';
 
-    if (idParts.length === 3) {
-      const [sourceId, edgeTypes, targetId] = idParts;
-      const edge = this._edgesMap.get(edgePathId);
+    // Removing from Edges Map
+    this._edgesMap.delete(edgeId);
 
-      // Removing from Edges Map
-      this._edgesMap.delete(edgePathId);
+    // Removing from outbound adjacency list
+    const outboundAdjElements = this._outboundAdjListMap.get(sourceId);
 
-      // Removing from outbound adjacency list
-      const outboundAdjElement = `${edgeTypes}>${targetId}`;
+    if (Array.isArray(outboundAdjElements)) {
+      this._outboundAdjListMap.set(
+        sourceId,
+        outboundAdjElements.filter(e => e !== edgeId),
+      );
+    }
 
-      const outboundAdjElements = this._outboundAdjListMap.get(sourceId);
+    // Removing from inbound adjacency list
+    const inboundAdjElements = this._inboundAdjListMap.get(targetId);
 
-      if (Array.isArray(outboundAdjElements)) {
-        this._outboundAdjListMap.set(
-          sourceId,
-          outboundAdjElements.filter(e => e !== outboundAdjElement),
-        );
-      }
-
-      // Removing from inbound adjacency list
-      const inboundAdjElement = `${sourceId}>${edgeTypes}`;
-
-      const inboundAdjElements = this._inboundAdjListMap.get(targetId);
-
-      if (Array.isArray(inboundAdjElements)) {
-        this._inboundAdjListMap.set(
-          targetId,
-          inboundAdjElements.filter(e => e !== inboundAdjElement),
-        );
-      }
-    } else {
-      throw new Error(`Invalid edge id: ${edgePathId}`);
+    if (Array.isArray(inboundAdjElements)) {
+      this._inboundAdjListMap.set(
+        targetId,
+        inboundAdjElements.filter(e => e !== edgeId),
+      );
     }
   }
 


### PR DESCRIPTION
This PR fixes an issue related to the removal of **edges**. In the previous implementation, a path id was used to remove an **edge**, which is invalid. This PR removes edges using the **external id**.